### PR TITLE
Guard against supply chain attacks using minReleaseAge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - checkout
       - restore_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
+      - run: npm install -g npm@11
       - run:
           name: Installing node modules
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,11 @@ orbs:
 jobs:
   run-tests:
     docker:
-      - image: cimg/node:22.9
+      - image: cimg/node:24.18
     steps:
       - checkout
       - restore_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
-      - run: sudo npm install -g npm@11
       - run:
           name: Installing node modules
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ orbs:
 jobs:
   run-tests:
     docker:
-      - image: cimg/node:22.0
+      - image: cimg/node:22.9
     steps:
       - checkout
       - restore_cache:
           key: v1-deps-{{ checksum "package-lock.json" }}
-      - run: npm install -g npm@11
+      - run: sudo npm install -g npm@11
       - run:
           name: Installing node modules
           command: npm install

--- a/.ecs_deploy/Dockerfile
+++ b/.ecs_deploy/Dockerfile
@@ -13,6 +13,7 @@ COPY . .
 
 COPY .ecs_deploy/docker-entrypoint.sh /usr/local/bin/
 
+RUN npm install -g npm@11
 RUN npm ci
 
 RUN chown -R node . \

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+min-release-age=21
+min-release-age-exclude=@blueprinthq/*
+engine-strict=true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY package*.json ./
 
+RUN npm install -g npm@11
 RUN npm install
 
 COPY . .

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Blueprint",
   "main": "app.js",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.0.0",
+    "npm": ">=11.10.0"
   },
   "scripts": {
     "start:dev": "env-cmd -e local node app",


### PR DESCRIPTION
#### Why this change?
[BP-16818](https://linear.app/blueprint-health/issue/BP-16818/guard-against-supply-chain-attacks-using-minreleaseage). npm packages can be compromised and published under a maintainer's legitimate credentials; most malicious releases get caught and unpublished within days. Setting `min-release-age=21` makes npm refuse to resolve any dependency version published less than 21 days ago, giving the community a window to catch and pull bad releases before this repo ever installs them.

#### Context for reviewers
- `min-release-age` requires npm >=11.10.0 to have any effect; older npm silently ignores the setting. `engine-strict=true` + `engines.npm` in package.json turns that into a hard `EBADENGINE` install failure instead of a silent no-op, so nobody is left thinking they're protected when they aren't.
- CircleCI's `run-tests` job and both `Dockerfile.dev` and `.ecs_deploy/Dockerfile` build on Node 22 base images whose bundled npm predates 11.10.0, so each now runs `npm install -g npm@11` immediately before its `npm install`/`npm ci` step. No Node runtime/CI image version was changed.
- `min-release-age-exclude=@blueprinthq/*` is included for consistency with our other repos, but this repo currently has no `@blueprinthq` scoped dependencies or private registry configured, so the exclusion is presently a no-op. Kept it anyway since it's harmless and future-proofs the config if this sample app ever adds a `@blueprinthq` package; happy to drop it if reviewers would rather keep this file minimal for a public-facing samples repo.