### PR TITLE
fix: correct the authenticate call, label the deprecated iframe view, fill README gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,31 @@ This sample application demonstrates typical integration scenarios:
 3. Host the embedded UI in your application and deepen the integration by using the API ("UI + API").
 4. Build your own UI and completely customize the integration via the API ("API Only").
 
+### Switching between the chart styles
+
+Each style is a separate template, selected with the `chartStyle` query
+parameter on the patient chart route. The links on the patients list page set it
+for you.
+
+| URL | Template | Shows |
+|---|---|---|
+| `/patients/:id` | `views/chart.ejs` | Embedded UI driven by the backend APIs (UI + API) |
+| `/patients/:id?chartStyle=uiOnly` | `views/chart-ui-only.ejs` | Embedded UI with no backend API calls |
+| `/patients/:id?chartStyle=miniWidget` | `views/chart-mini-widget.ejs` | Compact embedded UI with custom styling |
+| `/patients/:id?chartStyle=iframe` | `views/chart-with-iframe.ejs` | **Deprecated.** Hand-rolled iframe and raw postMessage |
+
+The iframe template is retained only for partners who cannot load a third-party
+script. It talks to an internal postMessage contract that can change without
+notice and reaches only the older full widget. Start from `chart.ejs` or
+`chart-mini-widget.ejs` instead.
+
+### Supply chain
+
+`.npmrc` sets `min-release-age=21`, which refuses npm packages published in the
+last 21 days, with `min-release-age-exclude=@blueprinthq/*` so Blueprint's own
+packages are exempt. This narrows the window in which a compromised release can
+be pulled into a build. Worth copying into your own project.
+
 Review Blueprint Partner API v2 documentation at
 [https://developer.blueprint.ai](https://developer.blueprint.ai) for more information
 and API reference.

--- a/app.js
+++ b/app.js
@@ -184,7 +184,7 @@ app.get('/patients/:id', async (req, res) => {
         'Access-Token': accessToken,
         'X-Api-Key': `${process.env.BLUEPRINT_API_KEY}`,
       },
-      body: JSON.stringify(),
+      // This endpoint takes no request body.
     }
   );
 

--- a/views/chart-mini-widget.ejs
+++ b/views/chart-mini-widget.ejs
@@ -68,7 +68,7 @@
         const encodedTokens = '<%- JSON.stringify(clinicianTokens) %>';
         const clinicianTokens = JSON.parse(decodeHtmlEntities(encodedTokens));
 
-        Blueprint.authenticate(clinicianTokens, '<%= clinicianId %>');
+        Blueprint.authenticate(clinicianTokens);
         // Selecting a client requires an authenticated clinician.
         // Upon selecting a client, a new session is created.
         // Optional properties can be passed to initialize the session with custom data.

--- a/views/chart-with-iframe.ejs
+++ b/views/chart-with-iframe.ejs
@@ -1,3 +1,17 @@
+<%#
+    DEPRECATED -- do not copy this as a starting point.
+
+    This page hand-rolls the iframe and speaks the BP_* postMessage protocol
+    directly, instead of loading the embed script from BLUEPRINT_WIDGET_URL and
+    using the window.Blueprint API as the other chart templates do.
+
+    It is kept only for partners who genuinely cannot load a third-party script.
+    The postMessage contract it uses is internal and can change without notice,
+    and it reaches only the older full widget -- the current compact widget is
+    not addressable this way.
+
+    Use views/chart.ejs or views/chart-mini-widget.ejs instead.
+%>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/views/chart.ejs
+++ b/views/chart.ejs
@@ -56,7 +56,7 @@
         const encodedTokens = '<%- JSON.stringify(clinicianTokens) %>';
         const clinicianTokens = JSON.parse(decodeHtmlEntities(encodedTokens));
 
-        Blueprint.authenticate(clinicianTokens, '<%= clinicianId %>');
+        Blueprint.authenticate(clinicianTokens);
         // Selecting a client requires an authenticated clinician.
         // Upon selecting a client, a new session is created.
         // Optional properties can be passed to initialize the session with custom data.


### PR DESCRIPTION
### Why this change?

[BP-18317](https://linear.app/blueprint-health/issue/BP-18317)

Four small independent corrections to things partners copy.

### Context for reviewers

**`Blueprint.authenticate` takes one argument.** Both chart templates passed a second (`clinicianId`). It is silently discarded, but its presence in the canonical sample implies it is meaningful.

**`body: JSON.stringify()`** on the clinician-auth call evaluates to `undefined`, so no body was sent. That is correct — the endpoint takes no body — but it reads as an oversight, so it is now a comment saying so rather than code that looks like a bug.

**The deprecated iframe view carried no warning in the file.** It was labelled "(deprecated)" on the patients list only, while being the one place the raw `BP_*` postMessage contract appears — so it is exactly the file someone lands in and copies. It now opens with a comment explaining that the protocol is internal and can change without notice, that it reaches only the older full widget, and which templates to start from instead.

**README gaps:** the `chartStyle` query parameter, which is how the sample demonstrates all four integration styles and was entirely undocumented; and the `.npmrc` `min-release-age` supply chain guard, which is worth copying.

**One ticket item turned out to be a no-op.** "Move credentials out of `config.ini`" — `config.ini` is gitignored, has never been committed (`git log --all` is empty for it), and is not part of the documented setup. The README has always pointed at `.env-cmdrc.json`, which is likewise gitignored with only a `.sample` tracked. The concern was about a personal scratch file, not anything in the repo, so there is no change here.

### Verification

`app.js` parses, all five EJS templates still render against representative data, and both `authenticate` call sites now pass one argument.

### Breaking changes

None — sample application only.

### Depends on

#25. Last of three stacked PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)